### PR TITLE
feat(payments): validate Wompi webhook forward from api.warocol.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ WOMPI_PUBLIC_KEY=pub_test_xxxxxxxxxxxxxxxxxxxxxxxxxx
 WOMPI_PRIVATE_KEY=prv_test_xxxxxxxxxxxxxxxxxxxxxxxxxx
 WOMPI_EVENTS_SECRET=your_wompi_events_secret_for_webhooks
 WOMPI_ENVIRONMENT=sandbox
+# Shared secret for api.warocol.com → Tickets webhook forward (must match warocol router)
+WOMPI_WEBHOOK_FORWARD_SECRET=
+
 
 # Production keys (uncomment for production)
 # WOMPI_PUBLIC_KEY=pub_prod_xxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.wr/46.yaml
+++ b/.wr/46.yaml
@@ -1,0 +1,33 @@
+# Machine contract for wr-fast — issue #46
+issue: 46
+title: "feat(payments): Accept forwarded Wompi webhooks from api.warocol.com router (internal auth)"
+repo: api_warotickets
+repo_remote: uno0uno/api_warotickets
+cwd: /Users/saifer/Documents/WEBS/WARO TICKETS/api_warotickets
+stack: fastapi
+branch: wr-46-wompi-forward-webhook
+epic: uno0uno/api-warolabs#351
+
+paths:
+  - app/routers/payments.py
+  - app/config.py
+  - .env.example
+  - tests/unit/test_payments.py
+
+ac:
+  - Internal auth (X-Wompi-Forward-Secret) validates requests from api.warocol.com router
+  - Forwarded body calls process_gateway_webhook('wompi', event_data) unchanged
+  - Public POST /payments/webhooks/wompi kept for transition
+  - Idempotency via was_already_approved guard in payments_service
+  - .env.example documents WOMPI_WEBHOOK_FORWARD_SECRET
+
+out_of_scope:
+  - Router implementation (api-warolabs #353)
+
+hints:
+  entry: "app/routers/payments.py — wompi_webhook"
+  pattern: "Warocol forwards to same URL with X-Wompi-Forward-Secret (wompi_webhook_router_service.py:96-100)"
+  tests: "pytest tests/unit/test_payments.py -v -k forward"
+
+skip:
+  audits: [ux, color, typography]

--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,10 @@ class Settings(BaseSettings):
     wompi_events_secret: Optional[str] = Field(default=None, alias='WOMPI_EVENTS_SECRET')
     wompi_integrity_secret: Optional[str] = Field(default=None, alias='WOMPI_INTEGRITY_SECRET')
     wompi_environment: str = Field(default='sandbox', alias='WOMPI_ENVIRONMENT')
+    # Shared with api.warocol.com Wompi router when forwarding Tickets webhooks (#46)
+    wompi_webhook_forward_secret: Optional[str] = Field(
+        default=None, alias='WOMPI_WEBHOOK_FORWARD_SECRET'
+    )
 
     # App settings
     app_env: str = Field(default="development", alias='APP_ENV')

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -3,6 +3,8 @@ Payments Router - Wompi Gateway
 
 Integración con Wompi (wompi.co) para pagos en Colombia.
 """
+import secrets
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import List, Optional
 from app.core.dependencies import get_authenticated_user, AuthenticatedUser
@@ -14,6 +16,20 @@ from app.services import payments_service
 from app.config import settings
 
 router = APIRouter()
+
+WOMPI_FORWARD_SECRET_HEADER = "X-Wompi-Forward-Secret"
+
+
+def _verify_wompi_forward_secret(provided: str) -> None:
+    """Validate internal forward from api.warocol.com Wompi router."""
+    expected = settings.wompi_webhook_forward_secret
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Webhook forward secret not configured",
+        )
+    if len(provided) != len(expected) or not secrets.compare_digest(provided, expected):
+        raise HTTPException(status_code=401, detail="Invalid forward secret")
 
 
 # ============================================================================
@@ -109,7 +125,20 @@ async def wompi_webhook(request: Request):
     Webhook endpoint for Wompi payment notifications.
 
     Wompi sends transaction.updated events with signature for verification.
+
+    **Transition:** When the merchant event URL points at api.warocol.com, the
+    central router forwards here with ``X-Wompi-Forward-Secret`` (must match
+    ``WOMPI_WEBHOOK_FORWARD_SECRET``). Direct Wompi posts without that header
+    remain accepted until Wompi cutover is verified — do not remove this route
+    as the sole ingress until then.
+
+    **Internal forward:** If ``X-Wompi-Forward-Secret`` is present, it is
+    validated before processing; invalid or missing server config returns 401/503.
     """
+    forward_secret = request.headers.get(WOMPI_FORWARD_SECRET_HEADER)
+    if forward_secret is not None:
+        _verify_wompi_forward_secret(forward_secret)
+
     event_data = await request.json()
     await payments_service.process_gateway_webhook('wompi', event_data)
     return {"status": "received"}

--- a/tests/unit/test_payments.py
+++ b/tests/unit/test_payments.py
@@ -3,7 +3,9 @@ Tests para endpoints de pagos.
 """
 import pytest
 from httpx import AsyncClient
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+from app.config import settings
 
 from tests.utils.factories import ReservationFactory, PaymentFactory
 from tests.utils.mocks import MockDBConnection, MockDBContextManager, mock_authenticated_user
@@ -177,3 +179,43 @@ class TestWompiWebhook:
             )
 
         assert response.status_code == 400
+
+
+class TestWompiWebhookForwardAuth:
+    """Internal auth for api.warocol.com → Tickets webhook forward (#46)."""
+
+    @pytest.mark.asyncio
+    async def test_forward_secret_invalid(self, client: AsyncClient):
+        with patch.object(settings, "wompi_webhook_forward_secret", "expected-secret"):
+            response = await client.post(
+                "/payments/webhooks/wompi",
+                json={"event": "transaction.updated"},
+                headers={"X-Wompi-Forward-Secret": "wrong-secret"},
+            )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_forward_secret_valid(self, client: AsyncClient):
+        with patch.object(settings, "wompi_webhook_forward_secret", "expected-secret"):
+            with patch(
+                "app.services.payments_service.process_gateway_webhook",
+                new_callable=AsyncMock,
+            ) as mock_process:
+                response = await client.post(
+                    "/payments/webhooks/wompi",
+                    json={"event": "transaction.updated", "data": {}},
+                    headers={"X-Wompi-Forward-Secret": "expected-secret"},
+                )
+        assert response.status_code == 200
+        assert response.json() == {"status": "received"}
+        mock_process.assert_awaited_once_with("wompi", {"event": "transaction.updated", "data": {}})
+
+    @pytest.mark.asyncio
+    async def test_forward_secret_unconfigured(self, client: AsyncClient):
+        with patch.object(settings, "wompi_webhook_forward_secret", None):
+            response = await client.post(
+                "/payments/webhooks/wompi",
+                json={"event": "transaction.updated"},
+                headers={"X-Wompi-Forward-Secret": "any"},
+            )
+        assert response.status_code == 503


### PR DESCRIPTION
## Summary

- Validate `X-Wompi-Forward-Secret` on `POST /payments/webhooks/wompi` when the api.warocol.com router forwards (same URL as direct Wompi during transition).
- Add `WOMPI_WEBHOOK_FORWARD_SECRET` to settings and `.env.example` (aligned with api-warolabs router).
- Unit tests for invalid, valid, and unconfigured forward secret.

Closes #46

## Test plan

- [ ] Set matching `WOMPI_WEBHOOK_FORWARD_SECRET` on warocol + Tickets; router forward with header succeeds (`{"status":"received"}`)
- [ ] Wrong header → 401; header present but secret unset on Tickets → 503
- [ ] Direct Wompi POST without header still works until cutover
- [ ] `pytest tests/unit/test_payments.py -v -k forward`

## wr-context

See `.wr/46.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)